### PR TITLE
Update files.php

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -24,7 +24,7 @@ return [
         }
     ],
     [
-        'pattern' => '(:all)/files',
+        'pattern' => '(:all?)/files',
         'method'  => 'GET',
         'action'  => function (string $path) {
             return $this->parent($path)->files()->sortBy('sort', 'asc', 'filename', 'asc');


### PR DESCRIPTION
added lazy quantifier to make the files route less specific


## Describe the PR

- https://github.com/TimOetting/kirby-builder/issues/110
- https://github.com/getkirby/editor/issues/175
- https://github.com/TimOetting/kirby-builder/issues/148
- https://forum.getkirby.com/t/possible-fix-for-kirby-builder-bug-with-image-picker-invalid-file-model-type-kirby-builder-pages-mypage-fields/18737/4

As described in the above linked discussions the kirby-builder plugin by timoetting has a problem with overwriting the kirby routes to allow for already uploaded images to be choosen with the filepicker. Different solutions have been brought up, but it seems the problem lies with how kirby specifies the routes. When adding the proposed patch to kirby-core, it seems to work again. My knowledge of the kirby routing is novice at best, but it would love to start a discussion if this would be a viable way to fix this. Maybe someone from the core team can tell me why this is a bad idea or why it wont work. But maybe it will?

I would love to help more, test, or verify if this is the right solution. If someone could point me to a direction, i would gladly do what i can! I hope create a PR was not wrong, i just want to help! I'm not mad if it gets deleted, because i did it the wrong way, if someone could tell me the right way :D 

## Related issues

maybe this one? i am not sure: https://github.com/getkirby/kirby/issues/2689

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Fixed code style issues with CS fixer and `composer fix`
- [ ] Added in-code documentation (if needed)
